### PR TITLE
Fixes #6. Repairs confirmation step for proposal destroy.

### DIFF
--- a/app/views/control/proposals/index.html.haml
+++ b/app/views/control/proposals/index.html.haml
@@ -5,7 +5,7 @@
     - @unsafe.each do |proposal|
       %li
         = link_to proposal.slug[0,6], edit_control_event_proposal_path(@event, proposal), class: 'slug'
-        %span.destroy= link_to '(destroy)', control_event_proposal_path(@event, proposal), method: :delete, confirm: "Destroy for realsies?"
+        %span.destroy= link_to '(destroy)', control_event_proposal_path(@event, proposal), method: :delete, :'data-confirm' => "Destroy for realsies?"
         %span.notes=  notes_for proposal
         %span.updated= "updated: #{ last_updated proposal }"
 


### PR DESCRIPTION
Dunno if this was an upgrade issue or what, but `link_to` wasn't constructing the `data-confirm` attribute in the anchor right, so the ujs wasn't picking it up when the link was activated. So I'm using ugly symbols now, but the task was to fix the destroy confirmation, not rewrite the view.

I really wanna rewrite all the views. :(
