### PR TITLE
Stop hardcoding email addresses in the notification routine.

### DIFF
--- a/app/controllers/collect_controller.rb
+++ b/app/controllers/collect_controller.rb
@@ -99,9 +99,9 @@ class CollectController < ApplicationController
 
   def send_confirmation_email
     mailer = Postmark::ApiClient.new ENV['POSTMARK_API_KEY']
-    mailer.deliver from:      'cfp@opensourceandfeelings.com',
+    mailer.deliver from:      ENV['CFP_FROM'],
                    to:        @proposal.get_email_address,
-                   bcc:       'cfp@opensourceandfeelings.com',
+                   bcc:       ENV['CFP_BCC'],
                    subject:   "Thank you for submitting to #{ @proposal.event.title }!",
                    tag:       'cfp-thanks',
                    html_body: render_to_string(layout: false, template: "collect/thanks")


### PR DESCRIPTION
We've some mail forwarding issues, so getting those addresses from the project ENV will let us tweak those addresses without having to redeploy the app.
